### PR TITLE
fix(setup): remove typo from entry author

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setup(
     name="APISpec-fromfile",
     version="1.0.1",
-    author="OVHCloud",
+    author="OVHcloud",
     author_email="opensource@ovhcloud.com",
     description="APISpec plugin to import OpenAPI specifications from a file instead of putting YAML into docstrings",
     long_description=long_description,


### PR DESCRIPTION
## :bug: Bug Fixes

Replace `OVHCloud` by `OVHcloud`.

948fcc8 - fix(setup): remove typo from entry author

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>