### PR TITLE
build: specify the apispec min version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,15 +22,16 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
         "Topic :: Documentation",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     keywords="openapi apispec",
     install_requires=[
-        "apispec[yaml]",
+        "apispec[yaml]>=4.0.0",
     ],
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     tests_require=["pytest"],
     test_suite="tests",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist=
 
 [testenv]
 deps=
-    apispec
     pytest
 commands=pytest {posargs} tests
 


### PR DESCRIPTION
The minimal version of apispec is 4.0.0. Tox doesn't need it direct deps and will install the one recommended in setup.

The supported python version is then 3.6: the python 3 classifier is added.