### PR TITLE
feat: use pre-commit to run linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v6.0.0
+  hooks:
+  - id: check-added-large-files
+  - id: check-executables-have-shebangs
+  - id: check-yaml
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.4.2
+  hooks:
+  - id: codespell
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.15.10
+  hooks:
+  - id: ruff
+  - id: ruff-format
+
+- repo: https://github.com/python-jsonschema/check-jsonschema
+  rev: 0.37.1
+  hooks:
+  - id: check-github-workflows
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.20.1
+  hooks:
+  - id: mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [build-system]
 requires = ["setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+line-length = 150

--- a/src/apispec_fromfile/__init__.py
+++ b/src/apispec_fromfile/__init__.py
@@ -4,9 +4,7 @@ from .plugin import FromFilePlugin
 from .plugin import from_file
 
 
-__version__ = str(
-    pkg_resources.get_distribution("apispec-fromfile").parsed_version
-)
+__version__ = str(pkg_resources.get_distribution("apispec-fromfile").parsed_version)
 
 __all__ = [
     "FromFilePlugin",

--- a/src/apispec_fromfile/plugin.py
+++ b/src/apispec_fromfile/plugin.py
@@ -1,4 +1,4 @@
-""" Plugin class """
+"""Plugin class"""
 
 from pathlib import Path
 
@@ -18,7 +18,7 @@ class FromFilePlugin(BasePlugin):
         self.func_key = func_key
 
     def operation_helper(self, path=None, operations=None, **kwargs):
-        """ apispec operation helper """
+        """apispec operation helper"""
         # get the endpoint name
         view = kwargs.pop(self.func_key)
 
@@ -60,7 +60,7 @@ def load_spec(func, path):
 
 
 def from_file(spec_path, live_reload: bool = False):
-    """ Decorate an endpoint with an OpenAPI spec file to import. """
+    """Decorate an endpoint with an OpenAPI spec file to import."""
 
     def wrapper(func):
         # save the content in a special attribute of the function

--- a/tests/test_fromfile.py
+++ b/tests/test_fromfile.py
@@ -1,4 +1,4 @@
-""" Test for apispec_fromfile """
+"""Test for apispec_fromfile"""
 
 from apispec import APISpec
 from apispec.exceptions import APISpecError
@@ -10,7 +10,7 @@ from apispec_fromfile import from_file
 
 
 def test_from_file_decorator(tmp_path):
-    """ Test the from_file decorator. """
+    """Test the from_file decorator."""
     # create a temp yaml file
     yaml_content = """
     ---
@@ -36,7 +36,7 @@ def test_from_file_decorator(tmp_path):
 
 
 def test_plugin():
-    """ Test the FromFilePlugin class. """
+    """Test the FromFilePlugin class."""
     # init the spec
     spec = APISpec(
         title="Petstore",
@@ -62,7 +62,7 @@ def test_plugin():
 
 
 def test_readme():
-    """ Test the code in the readme file """
+    """Test the code in the readme file"""
     # Create an APISpec
     spec = APISpec(
         title="Swagger Petstore",

--- a/tests/test_live_reload.py
+++ b/tests/test_live_reload.py
@@ -1,4 +1,4 @@
-""" Test for apispec_fromfile """
+"""Test for apispec_fromfile"""
 
 from apispec import APISpec
 from apispec.yaml_utils import load_operations_from_docstring
@@ -7,7 +7,7 @@ from apispec_fromfile import FromFilePlugin
 from apispec_fromfile import from_file
 
 
-def write_yaml_file(path, summary: str = 'Hello'):
+def write_yaml_file(path, summary: str = "Hello"):
     """
     Generate method spec with given summary and save in an external file
     """
@@ -60,17 +60,17 @@ def test_spec_is_not_updated_without_live_reload_flag(tmp_path):
         return "hello"
 
     yaml_operations_loaded = load_operations_from_docstring(yaml_content)
-    assert yaml_operations_loaded == make_spec(hello).to_dict()['paths']['/hello']
+    assert yaml_operations_loaded == make_spec(hello).to_dict()["paths"]["/hello"]
 
     # update file contents
-    yaml_file, yaml_content_updated = write_yaml_file(tmp_path, summary='Hello world')
+    yaml_file, yaml_content_updated = write_yaml_file(tmp_path, summary="Hello world")
     yaml_operations_updated_loaded = load_operations_from_docstring(yaml_content_updated)
 
     # check that yaml content has changed, but the method spec has not
     assert yaml_operations_loaded != yaml_operations_updated_loaded
-    assert yaml_operations_loaded == make_spec(hello).to_dict()['paths']['/hello']
-    assert yaml_operations_updated_loaded != make_spec(hello).to_dict()['paths']['/hello']
-    assert yaml_operations_updated_loaded['get']['summary'] == "Hello world"
+    assert yaml_operations_loaded == make_spec(hello).to_dict()["paths"]["/hello"]
+    assert yaml_operations_updated_loaded != make_spec(hello).to_dict()["paths"]["/hello"]
+    assert yaml_operations_updated_loaded["get"]["summary"] == "Hello world"
 
 
 def test_spec_is_updated_with_live_reload_flag(tmp_path):
@@ -86,14 +86,14 @@ def test_spec_is_updated_with_live_reload_flag(tmp_path):
         return "hello"
 
     yaml_operations_loaded = load_operations_from_docstring(yaml_content)
-    assert yaml_operations_loaded == make_spec(hello).to_dict()['paths']['/hello']
+    assert yaml_operations_loaded == make_spec(hello).to_dict()["paths"]["/hello"]
 
     # update file contents
-    yaml_file, yaml_content_updated = write_yaml_file(tmp_path, summary='Hello world')
+    yaml_file, yaml_content_updated = write_yaml_file(tmp_path, summary="Hello world")
     yaml_operations_updated_loaded = load_operations_from_docstring(yaml_content_updated)
 
     # check that yaml content has changed, and the method spec as well
     assert yaml_operations_loaded != yaml_operations_updated_loaded
-    assert yaml_operations_loaded != make_spec(hello).to_dict()['paths']['/hello']
-    assert yaml_operations_updated_loaded == make_spec(hello).to_dict()['paths']['/hello']
-    assert yaml_operations_updated_loaded['get']['summary'] == "Hello world"
+    assert yaml_operations_loaded != make_spec(hello).to_dict()["paths"]["/hello"]
+    assert yaml_operations_updated_loaded == make_spec(hello).to_dict()["paths"]["/hello"]
+    assert yaml_operations_updated_loaded["get"]["summary"] == "Hello world"

--- a/tox.ini
+++ b/tox.ini
@@ -12,10 +12,10 @@ commands =
 
 [testenv:lint]
 deps =
-    flake8
+    pre-commit
 skip-install = true
 commands =
-    flake8 src tests
+    pre-commit run --all-files --show-diff-on-failure
 
 [flake8]
 extend-ignore = E501


### PR DESCRIPTION
Some linters are added (codespell, jsonschema, mypy) and flake8 is replaced with ruff (with direct application).