### PR TITLE
build: extract the lib version dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ def hello():
 spec.path("/hello", resource=hello)
 ```
 
+To get the version of the library, use feature detection:
+
+```python
+from importlib.metadata
+
+importlib.metadata.version("apispec_fromfile")
+```
+
 # Related links
 
 * Contribute: https://github.com/ovh/python-apispec-fromfile/blob/master/CONTRIBUTING.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [project]
 name = "apispec-fromfile"
-version = "1.0.3"
 authors = [
     { name = "OVHcloud", email = "opensource@ovhcloud.com" },
 ]
@@ -12,6 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apispec[yaml]>=6.9.0",
 ]
+dynamic = ["version"]
 keywords = ["openapi", "apispec"]
 classifiers = [
     "Environment :: Plugins",
@@ -33,7 +33,7 @@ classifiers = [
 Repository = "https://github.com/ovh/python-apispec-fromfile"
 
 [build-system]
-requires = ["setuptools>=77.0.3"]
+requires = ["setuptools>=80", "setuptools-scm[simple]>=9.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]

--- a/src/apispec_fromfile/__init__.py
+++ b/src/apispec_fromfile/__init__.py
@@ -1,10 +1,6 @@
-import pkg_resources
-
 from .plugin import FromFilePlugin
 from .plugin import from_file
 
-
-__version__ = str(pkg_resources.get_distribution("apispec-fromfile").parsed_version)
 
 __all__ = [
     "FromFilePlugin",

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ envlist =
 [testenv]
 deps =
     pytest
-    setuptools<82
 commands =
     pytest {posargs} tests
 


### PR DESCRIPTION
The `pkg-resources` dependency is removed from `setuptools`. The version is now extracted via `setuptools-scm`.
To get the version, feature detection should be used instead of `__version__`:
```
importlib.metadata.version("apispec_fromfile")
```