### PR TITLE
test: add zizmor to pre-commit hooks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -15,20 +18,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install tox
-
       - name: Run tox for py${{ matrix.python-version }}
         run: tox -e py
-
       - name: Run extra tox targets
         run: tox -e lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,12 +19,17 @@ repos:
   - id: ruff
   - id: ruff-format
 
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.20.1
+  hooks:
+  - id: mypy
+
 - repo: https://github.com/python-jsonschema/check-jsonschema
   rev: 0.37.1
   hooks:
   - id: check-github-workflows
 
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.20.1
+- repo: https://github.com/zizmorcore/zizmor-pre-commit
+  rev: v1.24.1
   hooks:
-  - id: mypy
+  - id: zizmor


### PR DESCRIPTION
zizmor recommends to use hashes for github actions versions.